### PR TITLE
Add Wayback-Archive to Capture Operators & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Tools and services for capturing, replaying, and analyzing web content.
   - **Type:** CLI
   - **Open Source:** Yes
   - **Platform:** Linux / macOS / Windows
+* **[Wayback-Archive](https://github.com/GeiserX/Wayback-Archive)** - Downloads complete websites from the Wayback Machine with full asset preservation for offline viewing.
+  - **Type:** CLI
+  - **Open Source:** Yes
+  - **Platform:** Linux / macOS / Windows
 * **[Archivenow](https://github.com/oduwsdl/archivenow)** - Command-line tool to push resources into web archives.
   - **Type:** CLI
   - **Open Source:** Yes


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Capture Operators & Services** section under Web Archiving.
- Wayback-Archive is an open-source Python CLI tool (GPL-3.0) that downloads complete websites from the Wayback Machine and reconstructs them for fully functional offline viewing. It preserves all assets (HTML, CSS, JS, images, fonts), rewrites URLs to relative paths, and cleans up Wayback Machine artifacts.
- Placed alphabetically after the existing Wayback (wabarc) entry, following the established format with Type/Open Source/Platform metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)