### PR TITLE
Add Telegram-Archive to Messengers & Chats section

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ Tools for archiving content beyond traditional web pages.
   - **Type:** CLI
   - **Open Source:** Yes
   - **Platform:** Linux / macOS / Windows
+* **[Telegram-Archive](https://github.com/GeiserX/Telegram-Archive)** - Docker-based tool to export and archive complete Telegram chat histories including media, preserving messages in structured formats.
+  - **Type:** CLI
+  - **Open Source:** Yes
+  - **Platform:** Docker
 
 ### Specific CMS
 * **[wparc](https://github.com/ruarxive/wparc)** - Archives WordPress API data and files.


### PR DESCRIPTION
## Summary
- Adds [Telegram-Archive](https://github.com/GeiserX/Telegram-Archive) to the Messengers & Chats section
- Telegram-Archive provides automated, incremental Telegram history backups with a local web viewer that feels like the real app. Docker-ready and supports public chat sharing
- Entry placed in alphabetical order following the existing format