### PR TITLE
Add Wayback-Archive to Capture Operators & Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Tools and services for capturing, replaying, and analyzing web content.
   - **Type:** Service
   - **Open Source:** No
   - **Platform:** Cloud
+* **[Wayback-Archive](https://github.com/GeiserX/Wayback-Archive)** - CLI tool to bulk-download full website snapshots from the Wayback Machine, preserving original directory structure with all assets.
+  - **Type:** CLI
+  - **Open Source:** Yes
+  - **Platform:** Linux / macOS / Windows
 
 ## Social Networks
 


### PR DESCRIPTION
## Summary
- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the Capture Operators & Services section
- Wayback-Archive downloads complete websites from the Wayback Machine with full asset preservation for offline viewing